### PR TITLE
NC-478 use numpy serialization + b64 for high precision transport

### DIFF
--- a/displacy/displacy_service/parse.py
+++ b/displacy/displacy_service/parse.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import base64
 
 class Parse(object):
     def __init__(self, nlp, text, collapse_punctuation, collapse_phrases):
@@ -25,9 +26,11 @@ class Parse(object):
             for np in list(self.doc.noun_chunks):
                 np.merge(np.root.tag_, np.root.lemma_, np.root.ent_type_)
 
-    # de-numpy this vector
+    # numpy can serialize this itself without loss of precision
+    # but we then need to b64 the string so json can eat it.
     def serialize_vector(self, vector):
-        return [float(i) for i in vector]
+        bytes = vector.tostring()
+        return base64.b64encode(bytes).decode('ascii')
 
     def to_json(self):
         words = [{'text': w.text, 'tag': w.tag_, 
@@ -35,7 +38,7 @@ class Parse(object):
                 'ent_type': w.ent_type_, 'shape': w.shape_,
                 'lemma': w.lemma_, 'sentiment': w.sentiment,
                 'like_num': w.like_num, 'like_email': w.like_email,
-                'dep': w.dep_, 'vector': self.serialize_vector(w.vector)
+                'dep': w.dep_, 'serialized_vector': self.serialize_vector(w.vector)
                 } for w in self.doc]
         arcs = []
         for word in self.doc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+  spacy:
+    build: .
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
Floating point jitter will mess this up, we need to use numpy's high precision serialization to transport this over the wire.